### PR TITLE
Update package.json - Fix json typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "node --loader ts-node/esm --inspect ./src/auth.ts",
     "lint:eslint": "eslint --cache --max-warnings 0  \"{src,mock}/**/*.{ts,tsx}\" --fix",
     "lint:prettier": "prettier --write  \"src/**/*.{js,json,tsx,md}\"",
-    "lint:lint-staged": "lint-staged",
+    "lint:lint-staged": "lint-staged"
   },
   "keywords": [
     "chatgpt",


### PR DESCRIPTION
43 error JSON.parse Expected double-quoted property name in JSON at position 508 while parsing '{
43 error JSON.parse   "name": "chatgpt-wechatbot",
43 error JSON.parse   "vers'
44 error JSON.parse Failed to parse JSON data.
44 error JSON.parse Note: package.json must be actual JSON, not just JavaScript.